### PR TITLE
Some mapping optimisation ideas

### DIFF
--- a/src/mappings/helpers.ts
+++ b/src/mappings/helpers.ts
@@ -75,17 +75,18 @@ export function getToken(tokenAddress: Address): Token {
   let token = Token.load(tokenAddress.toHexString());
   if (token == null) {
     token = new Token(tokenAddress.toHexString());
+    let erc20 = ERC20Metadata.bind(tokenAddress);
+    let symbol = erc20.try_symbol();
+    let name = erc20.try_name();
+    let totalSupply = erc20.try_totalSupply();
+  
+    token.symbol = symbol.reverted ? '' : symbol.value;
+    token.name = name.reverted ? '' : name.value;
+    token.totalSupply = totalSupply.reverted
+      ? BigInt.fromI32(0)
+      : totalSupply.value;
+    token.save()
   }
-  let erc20 = ERC20Metadata.bind(tokenAddress);
-  let symbol = erc20.try_symbol();
-  let name = erc20.try_name();
-  let totalSupply = erc20.try_totalSupply();
-
-  token.symbol = symbol.reverted ? '' : symbol.value;
-  token.name = name.reverted ? '' : name.value;
-  token.totalSupply = totalSupply.reverted
-    ? BigInt.fromI32(0)
-    : totalSupply.value;
   return token as Token;
 }
 
@@ -105,6 +106,7 @@ export function getFee(feesAddress: Address): Fee {
     fees.randomRedeemFee = BigInt.fromI32(0);
     fees.targetRedeemFee = BigInt.fromI32(0);
     fees.swapFee = BigInt.fromI32(0);
+    fees.save();
   }
   return fees as Fee;
 }
@@ -170,7 +172,6 @@ export function getVault(vaultAddress: Address): Vault {
 
     let fees = getFee(vaultAddress);
     vault.fees = fees.id;
-    fees.save();
 
     let features = getFeature(vaultAddress);
     vault.features = features.id;
@@ -235,6 +236,7 @@ export function getPool(poolAddress: Address, blockNumber: BigInt): Pool {
     pool.deployBlock = blockNumber;
     pool.totalRewards = BigInt.fromI32(0);
     // vault and tokens not set
+    pool.save();
   }
   return pool as Pool;
 }

--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -35,18 +35,15 @@ export function handleRewardWithdrawn(event: RewardWithdrawnEvent): void {
 
   pool.totalRewards = pool.totalRewards.plus(amount);
 
-  let rewardToken = getToken(
+  getToken(
     Address.fromHexString(pool.rewardToken) as Address,
   );
-  rewardToken.save();
 
-  let stakingToken = getToken(
+  getToken(
     Address.fromHexString(pool.stakingToken) as Address,
   );
-  stakingToken.save();
 
-  let dividendToken = getToken(poolAddress);
-  dividendToken.save();
+  getToken(poolAddress);
 
   pool.save();
 }
@@ -75,6 +72,7 @@ export function handleTransfer(event: TransferEvent): void {
     let userAddress = event.params.from;
     let user = getStakedLpUser(userAddress);
     let poolInstance = RewardDistributionToken.bind(poolAddress);
+    // TODO: This eth-call could be avoided by keeping track of the balance in the database
     let balanceFromInstance = poolInstance.try_balanceOf(userAddress);
     let balance = balanceFromInstance.reverted
       ? BigInt.fromI32(0)
@@ -122,6 +120,4 @@ export function handleTransfer(event: TransferEvent): void {
 
   let dividendToken = getToken(poolAddress);
   dividendToken.save();
-
-  pool.save();
 }


### PR DESCRIPTION
Two patterns that I saw could be optimised:
- Only save entities if something actually changed
- Only do eth-calls the first time a entity is created
- Try to avoid eth-calls by keeping track of aggregation numbers (totalSupply, etc) inside the subgraph